### PR TITLE
Using the ballista now triggers an ATC message

### DIFF
--- a/code/modules/overmap/legacy/disperser/disperser_fire.dm
+++ b/code/modules/overmap/legacy/disperser/disperser_fire.dm
@@ -46,6 +46,11 @@
 	handle_overbeam()
 	qdel(atomcharge)
 
+	spawn(rand(20, 100) SECONDS)
+		SSlegacy_atc.msg("This is [(LEGACY_MAP_DATUM).dock_name] Control to all vessels in the [(LEGACY_MAP_DATUM).starsys_name] system. Priority travel advisory follows.")
+		sleep(5 SECONDS)
+		SSlegacy_atc.msg("Use caution for anomalous energy signatures consistent with obstruction disperser beam usage near sector coordinates [linked.x], [linked.y]. Control out.")
+
 	//Some moron disregarded the cooldown warning. Let's blow in their face.
 	if(prob(cool_failchance()))
 		explosion(middle,rand(1,2),rand(2,3),rand(3,4))


### PR DESCRIPTION

## About The Pull Request

Using the obstruction removal ballista will now trigger the ATC to broadcast an advisory about it within the next 20-100 seconds. This includes giving the approximate coordinates of where the beam came from.

This PR was tested locally.

## Why It's Good For The Game

Using the ballista is a bit of a big deal since it's basically a big space cannon. It makes sense that the ATC would warn other vessels about it, especially considering it could be used offensively in the wrong hands. Plus, it helps make the ATC a bit more meaningful and not just fluff.

## Changelog
:cl:
add: Using the obstruction removal ballista will now prompt the local ATC to issue a travel advisory about it.
/:cl:
