### PR TITLE
Fixes resleeving code

### DIFF
--- a/code/modules/resleeving/machines/body_printer.dm
+++ b/code/modules/resleeving/machines/body_printer.dm
@@ -92,6 +92,8 @@
 			/datum/prototype/material/steel::id = materials_limit,
 			/datum/prototype/material/glass::id = materials_limit,
 		))
+	if(bottles_limit)
+		bottles = new()
 	update_icon()
 
 /obj/machinery/resleeving/body_printer/Destroy()
@@ -156,6 +158,35 @@
 			target = src,
 		)
 		return CLICKCHAIN_DID_SOMETHING | CLICKCHAIN_DO_NOT_PROPAGATE
+
+/obj/machinery/resleeving/body_printer/using_item_on(obj/item/using, datum/event_args/actor/clickchain/clickchain, clickchain_flags)
+	. = ..()
+	if(. & CLICKCHAIN_FLAGS_INTERACT_ABORT)
+		return
+	if(!istype(using, /obj/item/reagent_containers/glass))
+		return
+	if(bottles_limit == 0)
+		clickchain.chat_feedback(
+			SPAN_NOTICE("\The [src] does not have any slot to put in a container."),
+			target = src
+		)
+		return
+	if(!bottles) bottles = new()
+	if(bottles.len >= bottles_limit)
+		clickchain.chat_feedback(
+			SPAN_NOTICE("\The [src] is full."),
+			target = src
+		)
+		return
+
+	if(!clickchain.performer.attempt_insert_item_for_installation(using, src))
+		return
+	bottles += using
+	clickchain.chat_feedback(
+		SPAN_NOTICE("You put \the [using] into \the [src]."),
+		target = src
+	)
+	return CLICKCHAIN_DID_SOMETHING | CLICKCHAIN_DO_NOT_PROPAGATE
 
 /obj/machinery/resleeving/body_printer/drop_products(method, atom/where)
 	. = ..()

--- a/code/modules/resleeving/machines/body_printer.dm
+++ b/code/modules/resleeving/machines/body_printer.dm
@@ -93,7 +93,7 @@
 			/datum/prototype/material/glass::id = materials_limit,
 		))
 	if(bottles_limit)
-		bottles = new()
+		bottles = new/list()
 	update_icon()
 
 /obj/machinery/resleeving/body_printer/Destroy()
@@ -171,7 +171,6 @@
 			target = src
 		)
 		return
-	if(!bottles) bottles = new()
 	if(bottles.len >= bottles_limit)
 		clickchain.chat_feedback(
 			SPAN_NOTICE("\The [src] is full."),
@@ -194,7 +193,7 @@
 	if(bottles)
 		for(var/obj/item/I in bottles)
 			I.forceMove(where)
-		bottles = null
+		bottles = new/list()
 
 /obj/machinery/resleeving/body_printer/Exited(atom/movable/AM, atom/newLoc)
 	..()

--- a/code/modules/resleeving/machines/resleeving_console.dm
+++ b/code/modules/resleeving/machines/resleeving_console.dm
@@ -317,7 +317,9 @@
 			)
 			return CLICKCHAIN_DO_NOT_PROPAGATE | CLICKCHAIN_DID_SOMETHING
 		if(do_after(clickchain.performer, 1 SECOND, src))
-			var/mirror = mirrortool.remove_mirror(src)
+			if(!mirrortool.inserted_mirror)
+				return
+			var/obj/item/organ/internal/mirror/mirror = mirrortool.remove_mirror(src)
 			insert_mirror(mirror)
 			clickchain.chat_feedback(
 				SPAN_NOTICE("You line up \the [mirrortool] with \the [src]'s port and inject its mirror."),

--- a/code/modules/resleeving/machines/resleeving_console.dm
+++ b/code/modules/resleeving/machines/resleeving_console.dm
@@ -308,6 +308,22 @@
 			clickchain.performer.put_in_hands_or_drop(mirror)
 			return CLICKCHAIN_DO_NOT_PROPAGATE
 		return CLICKCHAIN_DID_SOMETHING | CLICKCHAIN_DO_NOT_PROPAGATE
+	if(istype(using, /obj/item/mirrortool))
+		var/obj/item/mirrortool/mirrortool = using
+		if(!mirrortool.inserted_mirror)
+			clickchain.chat_feedback(
+				SPAN_WARNING("\The [using] does not have a mirror in it."),
+				target = src
+			)
+			return CLICKCHAIN_DO_NOT_PROPAGATE | CLICKCHAIN_DID_SOMETHING
+		if(do_after(clickchain.performer, 1 SECOND, src))
+			var/mirror = mirrortool.remove_mirror(src)
+			insert_mirror(mirror)
+			clickchain.chat_feedback(
+				SPAN_NOTICE("You line up \the [mirrortool] with \the [src]'s port and inject its mirror."),
+				target = src
+			)
+			return CLICKCHAIN_DID_SOMETHING | CLICKCHAIN_DO_NOT_PROPAGATE
 	if(istype(using, /obj/item/disk/data))
 		if(inserted_disk)
 			clickchain.chat_feedback(

--- a/code/modules/resleeving/machines/resleeving_pod.dm
+++ b/code/modules/resleeving/machines/resleeving_pod.dm
@@ -106,7 +106,9 @@
 			)
 			return CLICKCHAIN_DO_NOT_PROPAGATE | CLICKCHAIN_DID_SOMETHING
 		if(do_after(clickchain.performer, 1 SECOND, src))
-			var/mirror = mirrortool.remove_mirror(src)
+			if(!mirrortool.inserted_mirror)
+				return
+			var/obj/item/organ/internal/mirror/mirror = mirrortool.remove_mirror(src)
 			insert_mirror(mirror)
 			clickchain.chat_feedback(
 				SPAN_NOTICE("You line up \the [mirrortool] with \the [src]'s port and inject its mirror."),

--- a/code/modules/resleeving/machines/resleeving_pod.dm
+++ b/code/modules/resleeving/machines/resleeving_pod.dm
@@ -97,6 +97,22 @@
 			clickchain.performer.put_in_hands_or_drop(mirror)
 			return CLICKCHAIN_DO_NOT_PROPAGATE
 		return CLICKCHAIN_DID_SOMETHING | CLICKCHAIN_DO_NOT_PROPAGATE
+	if(istype(using, /obj/item/mirrortool))
+		var/obj/item/mirrortool/mirrortool = using
+		if(!mirrortool.inserted_mirror)
+			clickchain.chat_feedback(
+				SPAN_WARNING("\The [using] does not have a mirror in it."),
+				target = src
+			)
+			return CLICKCHAIN_DO_NOT_PROPAGATE | CLICKCHAIN_DID_SOMETHING
+		if(do_after(clickchain.performer, 1 SECOND, src))
+			var/mirror = mirrortool.remove_mirror(src)
+			insert_mirror(mirror)
+			clickchain.chat_feedback(
+				SPAN_NOTICE("You line up \the [mirrortool] with \the [src]'s port and inject its mirror."),
+				target = src
+			)
+			return CLICKCHAIN_DID_SOMETHING | CLICKCHAIN_DO_NOT_PROPAGATE
 
 /obj/machinery/resleeving/resleeving_pod/proc/user_insert_mirror(datum/event_args/actor/actor, obj/item/organ/internal/mirror/mirror, silent, suppressed)
 	if(held_mirror)


### PR DESCRIPTION

## About The Pull Request

Fixes some missing backend to actually allow you to put bottles of biomass into grower pods. Also restores the mirror tool's ability to directly put mirrors into the resleeving machines.

This PR has been tested locally.

## Why It's Good For The Game

Currently, resleeving is completely nonfunctional since you can't load grower pods with biomass. This fixes that, and restores a previous QOL thing for the mirrortool.

## Changelog
:cl:
fix: Fixed grower pods not accepting bottles of biomass.
fix: Fixed being unable to use the mirror tool to directly put mirrors into machines.
/:cl:
