### PR TITLE
Endeavor Deck 1 Tweaks

### DIFF
--- a/maps/stations/endeavour/levels/deck1.dmm
+++ b/maps/stations/endeavour/levels/deck1.dmm
@@ -1823,6 +1823,10 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 10
 	},
+/obj/structure/table/woodentable,
+/obj/machinery/photocopier/faxmachine{
+	department = "Pilot Office"
+	},
 /turf/simulated/floor/wood,
 /area/exploration/pilot_Office)
 "bqQ" = (
@@ -23103,9 +23107,7 @@
 /area/hallway/d1portforhall/endeavour)
 "qIc" = (
 /obj/machinery/air_alarm{
-	frequency = 1441;
-	pixel_y = 22;
-	target_temperature = 275.15
+	pixel_y = 22
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/tool_storage)


### PR DESCRIPTION

## About The Pull Request

Fixes the air alarm in tool storage being set super low and also being set to a different frequency for some reason.

Adds a fax machine to the pilot's office.

## Why It's Good For The Game

1st one is an odd bugfix. 2nd one is simple QOL since pilots need to file flight plans and such.

## Changelog
:cl:
fix: The air alarm in the NSV Endeavor's tool storage is no longer set to 2 degrees.
tweak: The NSV Endeavor's pilot office now has a built-in fax machine. 
/:cl:
