### PR TITLE
fixes holosphere shells not getting real_name set resulting in quirky behaviour

### DIFF
--- a/code/modules/species/holosphere/transform.dm
+++ b/code/modules/species/holosphere/transform.dm
@@ -4,6 +4,7 @@
 		return
 	if(force || !IS_DEAD(holosphere_shell))
 		holosphere_shell.name = H.name
+		holosphere_shell.real_name = H.name
 		try_exit_recharge_station()
 		if(transform_component.try_transform())
 			H.drop_held_items()


### PR DESCRIPTION

## About The Pull Request
fix holosphere shells not getting real_name set resulting in quirky behaviour

example: dead holosphere's ghosts get the wrong name

## Why It's Good For The Game
fixes a bug

## Changelog
:cl:
fix: fixes holosphere shells not getting real_name set resulting in quirky behaviour
:cl:
